### PR TITLE
Add $options array to Account::createLoginLink

### DIFF
--- a/src/Concerns/ManagesAccount.php
+++ b/src/Concerns/ManagesAccount.php
@@ -266,16 +266,17 @@ trait ManagesAccount
     /**
      * Gets the Stripe account dashboard login URL.
      *
+     * @param $options
      * @return string
      * @throws AccountNotFoundException|ApiErrorException
      */
-    public function accountDashboardUrl(): ?string
+    public function accountDashboardUrl(array $options = []): ?string
     {
         $this->assertAccountExists();
 
         // Can only create login link if details has been submitted.
         return $this->hasSubmittedAccountDetails()
-            ? Account::createLoginLink($this->stripeAccountId(), [], $this->stripeAccountOptions())->url
+            ? Account::createLoginLink($this->stripeAccountId(), $options, $this->stripeAccountOptions())->url
             : null;
     }
 


### PR DESCRIPTION
This can allow the user to pass `redirect_url` so Stripe's dashboard displays a return to app link.

<img width="211" alt="image" src="https://user-images.githubusercontent.com/3401771/105966317-7adfbc80-6052-11eb-9bd8-c86b1ea221e5.png">
