### PR TITLE
Don't include 'stripe_account' on AccountLink call

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Please refer to [LICENSE.md](https://github.com/ExpDev07/laravel-cashier-stripe-
 This list only contains some of the most notable contributors. For the full list, refer to [GitHub's contributors graph](https://github.com/ExpDev07/laravel-cashier-stripe-connect/graphs/contributors).
 * ExpDev07 (Marius) - creator and maintainer.
 * Haytam Bakouane [(hbakouane)](https://github.com/hbakouane) - contributor.
+* Alex Powell [(theblindfrog)](https://github.com/theblindfrog) - contributor.
 
 ## Thanks to
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -30,13 +30,14 @@ trait Billable
      * The default Stripe API options for the current Billable model.
      *
      * @param array $options
+     * @param bool $includeAccountId Should we include the 'stripe_account' key to the options array by default
      * @return array
      */
-    public function stripeAccountOptions(array $options = []): array
+    public function stripeAccountOptions(array $options = [], bool $includeAccountId = true): array
     {
         // Include Stripe Account id if present. This is so we can make requests on the behalf of the account.
         // Read more: https://stripe.com/docs/api/connected_accounts?lang=php.
-        if ($this->hasStripeAccountId()) {
+        if ($this->hasStripeAccountId() && $includeAccountId) {
             $options['stripe_account'] = $this->stripeAccountId();
         }
 

--- a/src/Concerns/ManagesAccountLink.php
+++ b/src/Concerns/ManagesAccountLink.php
@@ -34,7 +34,7 @@ trait ManagesAccountLink
             'account' => $this->stripeAccountId(),
         ], $options);
 
-        return AccountLink::create($options, $this->stripeAccountOptions())->url;
+        return AccountLink::create($options, $this->stripeAccountOptions([], false))->url;
     }
 
     /**

--- a/src/Concerns/ManagesTransfer.php
+++ b/src/Concerns/ManagesTransfer.php
@@ -44,13 +44,14 @@ trait ManagesTransfer
      * Reverses a transfer back to the Connect Platform. This means the Stripe account will
      *
      * @param Transfer $transfer The transfer to reverse.
-     * @param bool $refundFee Whether to refund the application fee too.
      * @param int|null $amount The amount to reverse.
+     * @param bool $refundFee Whether to refund the application fee too.
      * @param array $options Any additional options.
      * @return TransferReversal
      * @throws AccountNotFoundException|ApiErrorException
      */
-    public function reverseTransferFromStripeAccount(Transfer $transfer, $refundFee = false, ?int $amount, array $options = []): TransferReversal
+    public function reverseTransferFromStripeAccount(Transfer $transfer, ?int $amount, $refundFee = false, array
+    $options = []): TransferReversal
     {
         $this->assertAccountExists();
 


### PR DESCRIPTION
This is already provided as the 'account' param. By including `stripe_account` in the call, the Stripe API call fails.

Happy to tweak the implementation - but this is currently broken.