### PR TITLE
Fix for Cashier 13.x

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -40,7 +40,7 @@ trait Billable
             $options['stripe_account'] = $this->stripeAccountId();
         }
 
-        return array_merge(Cashier::stripeOptions($options));
+        return array_merge(Cashier::stripe($options));
     }
 
 }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -39,8 +39,17 @@ trait Billable
         if ($this->hasStripeAccountId()) {
             $options['stripe_account'] = $this->stripeAccountId();
         }
+        
+        $stripeOptions = Cashier::stripe($options);
+        
+        // Workaround for Cashier 12.x 
+        if (version_compare(Cashier::VERSION, '12.15.0', '<=') {
+            return array_merge(Cashier::stripeOptions($options));
+        }
 
-        return array_merge(Cashier::stripe($options));
+        return array_merge($options, [
+            'api_key' => $stripeOptions->getApiKey()
+        ]);
     }
 
 }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -40,13 +40,13 @@ trait Billable
             $options['stripe_account'] = $this->stripeAccountId();
         }
         
-        $stripeOptions = Cashier::stripe($options);
-        
         // Workaround for Cashier 12.x 
         if (version_compare(Cashier::VERSION, '12.15.0', '<=') {
             return array_merge(Cashier::stripeOptions($options));
         }
 
+        $stripeOptions = Cashier::stripe($options);
+        
         return array_merge($options, [
             'api_key' => $stripeOptions->getApiKey()
         ]);


### PR DESCRIPTION
Cashier 13.x version renamed `stripeOptions` method to `stripe`.